### PR TITLE
Fixed typo in jarvice_cli

### DIFF
--- a/bin/jarvice_cli
+++ b/bin/jarvice_cli
@@ -222,7 +222,7 @@ def _set_credentials(args):
         config.update({'username': CParser.get('auth', 'username')})
         config.update({'apikey': CParser.get('auth', 'apikey')})
     else:
-        sys.write.stderr("username and apikey must be passed as arguments "
+        sys.sterr.write.("username and apikey must be passed as arguments "
                          "or set in ~/.jarvice.cfg")
         sys.exit(1)
 

--- a/bin/jarvice_cli
+++ b/bin/jarvice_cli
@@ -222,7 +222,7 @@ def _set_credentials(args):
         config.update({'username': CParser.get('auth', 'username')})
         config.update({'apikey': CParser.get('auth', 'apikey')})
     else:
-        sys.sterr.write("username and apikey must be passed as arguments "
+        sys.stderr.write("username and apikey must be passed as arguments "
                         "or set in ~/.jarvice.cfg")
         sys.exit(1)
 

--- a/bin/jarvice_cli
+++ b/bin/jarvice_cli
@@ -222,8 +222,8 @@ def _set_credentials(args):
         config.update({'username': CParser.get('auth', 'username')})
         config.update({'apikey': CParser.get('auth', 'apikey')})
     else:
-        sys.sterr.write.("username and apikey must be passed as arguments "
-                         "or set in ~/.jarvice.cfg")
+        sys.sterr.write("username and apikey must be passed as arguments "
+                        "or set in ~/.jarvice.cfg")
         sys.exit(1)
 
 


### PR DESCRIPTION
This PR fixes an error in line 255 of [jarvice_cli](https://github.com/nimbix/jarvice_cli/blob/master/bin/jarvice_cli#L225).
`sys.write.stderr` should become `sys.stderr.write`.